### PR TITLE
zadanie rekrutacyjne

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,3 +1,45 @@
 body {
     background-color: lightgray;
 }
+
+.rates-container {
+    display: flex;
+    flex-direction: column;
+    column-gap: 1em;
+    max-width: 800px;
+    margin: 1em auto;
+}
+
+.rates-container > div {
+    display: flex;
+    flex-direction: row;
+    justify-items: center;
+    column-gap: .5em;
+    margin-bottom: 1em;
+    font-weight: 600;
+}
+
+.rates-container th {
+    text-align: center;
+    vertical-align: center;
+}
+.rates-container td {
+    text-align: right;
+    padding-right: .5em;
+}
+.rates-container td:first-child{
+    text-align: center;
+}
+
+.rates-container thead {
+    background: white;
+}
+.rates-container tr:hover {
+    background: #e0e0e0;
+}
+
+.rates-container table,
+.rates-container th,
+.rates-container td {
+    border: 1px solid black;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -11,13 +11,15 @@
 // start the Stimulus application
 //import './bootstrap';
 
+import React from "react";
+import ReactDOM from "react-dom";
+import { BrowserRouter as Router } from "react-router-dom";
+import "../css/app.css";
+import Home from "./components/Home";
 
-
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
-import '../css/app.css';
-import Home from './components/Home';
-
-ReactDOM.render(<Router><Home /></Router>, document.getElementById('root'));
-
+ReactDOM.render(
+  <Router>
+    <Home />
+  </Router>,
+  document.getElementById("root"),
+);

--- a/assets/js/components/DatePicker.js
+++ b/assets/js/components/DatePicker.js
@@ -1,0 +1,23 @@
+import React, {useCallback} from "react";
+
+const DatePicker = ({ onDateChange, date, maxDate }) => {
+    const handleChange = useCallback(
+        ({ target }) => {
+            onDateChange(target.value);
+        },
+        [onDateChange],
+    );
+
+    return (
+        <div>
+            <input
+                min="2023-01-01"
+                max={maxDate}
+                type="date"
+                value={date ?? ""}
+                onChange={handleChange}
+            />
+        </div>
+    );
+};
+export default DatePicker

--- a/assets/js/components/ExchangeRates.js
+++ b/assets/js/components/ExchangeRates.js
@@ -1,0 +1,99 @@
+import React, { useEffect, useCallback, useMemo } from "react";
+import { useHistory, useParams } from "react-router-dom";
+import useRates from "../hooks/useRates";
+import DatePicker from "./DatePicker";
+
+const ExchangeRatesPage = () => {
+  const today = getCurrentDate();
+
+  const { date } = useParams();
+  const history = useHistory();
+  const [refRates, refRatesLoading] = useRates(today);
+  const [currentRates, currentRatesLoading] = useRates(date);
+
+  const onChangeDate = useCallback(
+    (value) => {
+      history.push(`/exchange-rates/${value}`);
+    },
+    [history],
+  );
+
+  useEffect(() => {
+    if (!date) {
+      history.push(`/exchange-rates/${today}`);
+    }
+  }, [today, date]);
+
+  const formatRate = (value) =>
+    value ? value.toLocaleString(undefined, { minimumFractionDigits: 4 }) : "-";
+
+  const formatDate = (value) => (value === today ? `Dzisiaj (${date})` : value);
+
+  const needsRefColumns = useMemo(
+    () => refRates && currentRates && refRates?.date != currentRates?.date,
+    [refRates, currentRates],
+  );
+  const refDateStr = useMemo(() => formatDate(refRates.date), [refRates]);
+  const isLoading = useMemo(
+    () => refRatesLoading || currentRatesLoading,
+    [refRatesLoading, currentRatesLoading],
+  );
+  console.log(currentRates.date)
+
+  return (
+    <div className="rates-container">
+      <div>
+        Wybierz datę{" "}
+        <DatePicker date={date} onDateChange={onChangeDate} maxDate={today} />
+      </div>
+      {isLoading ? (
+        "Trwa ładowanie kursów walut..."
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th rowSpan={2}>Waluta</th>
+              <th colSpan={needsRefColumns ? 2 : 1}>Skup</th>
+              <th colSpan={needsRefColumns ? 2 : 1}>Sprzedaż</th>
+            </tr>
+            <tr>
+              <th>{formatDate(currentRates.date)}</th>
+              {needsRefColumns && <th>{refDateStr}</th>}
+              <th>{formatDate(currentRates.date)}</th>
+              {needsRefColumns && <th>{refDateStr}</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {currentRates?.rates?.map((rate, key) => (
+              <tr key={key}>
+                <td>{rate.code}</td>
+                <td>{formatRate(rate.buy)}</td>
+                {needsRefColumns && (
+                  <td>
+                    {formatRate(
+                      refRates.rates.find(({ code }) => code === rate.code)
+                        ?.buy,
+                    )}
+                  </td>
+                )}
+                <td>{formatRate(rate.sell)}</td>
+                {needsRefColumns && (
+                  <td>
+                    {formatRate(
+                      refRates.rates.find(({ code }) => code === rate.code)
+                        ?.sell,
+                    )}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+const getCurrentDate = () => new Date().toISOString().substr(0, 10);
+
+export default ExchangeRatesPage;

--- a/assets/js/components/Home.js
+++ b/assets/js/components/Home.js
@@ -3,9 +3,9 @@
 import React, {Component} from 'react';
 import {Route, Redirect, Switch, Link} from 'react-router-dom';
 import SetupCheck from "./SetupCheck";
+import ExchangeRates from "./ExchangeRates";
 
 class Home extends Component {
-
     render() {
         return (
             <div>
@@ -16,13 +16,18 @@ class Home extends Component {
                             <li className="nav-item">
                                 <Link className={"nav-link"} to={"/setup-check"}> React Setup Check </Link>
                             </li>
+                            <li>
+                                <Link className={"nav-link"} to={"/exchange-rates"}> Exchange Rates </Link>
+                            </li>
 
                         </ul>
                     </div>
                 </nav>
                 <Switch>
                     <Redirect exact from="/" to="/setup-check" />
+                    dsldsldslddldldl
                     <Route path="/setup-check" component={SetupCheck} />
+                    <Route path="/exchange-rates/:date?" component={ExchangeRates} />
                 </Switch>
             </div>
         )

--- a/assets/js/hooks/useRates.js
+++ b/assets/js/hooks/useRates.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+const useRates = (date) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [rates, setRates] = useState({ date, rates: undefined });
+  const getRates = async (date) => {
+    const res = await fetch(`/api/rates/${date}`);
+    return res.ok ? await res.json() : null;
+  };
+
+  useEffect(async () => {
+    if (!date) {
+      return { rates: undefined, date };
+    }
+    setIsLoading(true);
+    const response = await getRates(date);
+    setRates(response);
+    setIsLoading(false);
+  }, [date, setRates]);
+
+  return [rates, isLoading];
+};
+
+export default useRates;

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -8,6 +8,14 @@ setupcheck:
     path: /api/setup-check
     controller: App\Controller\DefaultController::setupCheck
 
+rates:
+    path: /api/rates/{date}
+    controller: App\Controller\ExchangeRatesController::getRates
+    defaults:
+        date: 'today'
+    requirements:
+        date: '(today)|(\d{4}-\d{2}-\d{2})'
+
 index:
     path: /{wildcard}
     defaults: {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,3 +28,8 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    App\Helper\:
+        resource: '../src/App/Helper/'
+        autowire: true
+        tags: [ 'controller.service_arguments' ]

--- a/src/App/Controller/DefaultController.php
+++ b/src/App/Controller/DefaultController.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DefaultController extends AbstractController
 {
-
     public function index(): Response
     {
         return $this->render(

--- a/src/App/Controller/ExchangeRatesController.php
+++ b/src/App/Controller/ExchangeRatesController.php
@@ -5,9 +5,24 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\Helper\TransactionRatesHelper;
 
 class ExchangeRatesController extends AbstractController
 {
+    private $helper;
 
+    public function __construct(TransactionRatesHelper $helper) {
+        $this->helper = $helper;
+    }
 
+    public function getRates(Request $req, $date):Response {
+        $rates = $this->helper->getRates($date==='today'?date('Y-m-d'):$date);
+        return new Response(
+                    json_encode($rates),
+                    Response::HTTP_OK,
+                    ['Content-type' => 'application/json']
+                );
+    }
 }

--- a/src/App/Controller/ExchangeRatesController.php
+++ b/src/App/Controller/ExchangeRatesController.php
@@ -7,7 +7,9 @@ namespace App\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Exception\UnexpectedValueException;
 use App\Helper\TransactionRatesHelper;
+
 
 class ExchangeRatesController extends AbstractController
 {
@@ -18,7 +20,12 @@ class ExchangeRatesController extends AbstractController
     }
 
     public function getRates(Request $req, $date):Response {
-        $rates = $this->helper->getRates($date==='today'?date('Y-m-d'):$date);
+        $parsedDate = date_parse($date);
+        if($parsedDate['year']<2023) {
+            return new Response('',Response::HTTP_FORBIDDEN);
+        }
+
+        $rates = $this->helper->getRates($date);
         return new Response(
                     json_encode($rates),
                     Response::HTTP_OK,

--- a/src/App/Helper/NbpRatesHelper.php
+++ b/src/App/Helper/NbpRatesHelper.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Helper;
+use DateInterval;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+const SUPPORTED_CURRENCY_CODES = ['EUR','USD','CZK','IDR','BRL'];
+
+const MAX_RECURSIONS = 5;
+
+class NbpRatesHelper {
+    private $httpClient;
+    private $cache;
+
+    public function __construct(HttpClientInterface $httpCli, AdapterInterface $cache) {
+        $this->httpClient = $httpCli;
+        $this->cache = $cache;
+    }
+
+    public function getRates($date, $depth = 0) {
+            $rates = $this->cache->getItem('exchangerates.'.$date);
+
+            if(!$rates->get()) {
+
+                $response = $this->httpClient->request('GET',"https://api.nbp.pl/api/exchangerates/tables/A/$date?format=json");
+                if($response->getStatusCode()===404) {
+                    if($depth<MAX_RECURSIONS) {
+                        return $this->getRates($this->getPreviousDate($date),$depth+1);
+                    } else {
+                        throw new NotFoundHttpException("Cannot fetch data");
+                    }
+
+                }
+                $responseData = json_decode($response->getContent());
+                $supportedRates = array_values(array_filter($responseData[0]->rates, function($item) {
+                    return in_array($item->code,SUPPORTED_CURRENCY_CODES);
+                }));
+                $rates->set(['date'=>$date,'rates'=>$supportedRates]);
+                $this->cache->save($rates);
+
+
+            }
+        return $rates->get();
+    }
+
+    private function getPreviousDate($date) {
+        $parsed = date_create_immutable_from_format('Y-m-d',$date);
+        switch($parsed->format('D')) {
+            case 'Mon': $lookBack = 3; break;
+            case 'Sun': $lookBack = 2; break;
+            default: $lookBack = 1; break;
+        }
+        $lookBackPeriod = sprintf("P%dD",$lookBack);
+        return $parsed->sub(new DateInterval($lookBackPeriod))->format('Y-m-d');
+    }
+
+
+}

--- a/src/App/Helper/TransactionRatesHelper.php
+++ b/src/App/Helper/TransactionRatesHelper.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\Helper;
+
+const BUY_SPREADS = [
+    'EUR'=>0.05,
+    'USD'=>0.05
+];
+
+const SELL_SPREADS = [
+    'EUR'=>0.07,
+    'USD'=>0.07,
+    'CZK'=>0.15,
+    'IDR'=>0.15,
+    'BRL'=>0.15
+];
+
+
+class TransactionRatesHelper {
+    private $nbpHelper;
+
+    function __construct(NbpRatesHelper $nbpHelper) {
+        $this->nbpHelper = $nbpHelper;
+    }
+
+    public function getRates(string $date) {
+        $nbpRates = $this->nbpHelper->getRates($date);
+        $buySellRates = array_map(function($nbpRate) {
+            $buyRate = array_key_exists($nbpRate->code,BUY_SPREADS)?$nbpRate->mid-BUY_SPREADS[$nbpRate->code]:null;
+            $sellRate = array_key_exists($nbpRate->code,SELL_SPREADS)?$nbpRate->mid+SELL_SPREADS[$nbpRate->code]:null;
+            return ['code'=>$nbpRate->code, 'buy'=>$buyRate, 'sell'=>$sellRate];
+        }, $nbpRates['rates']);
+        return ['date'=>$nbpRates['date'],'rates'=>$buySellRates];
+    }
+
+}

--- a/tests/Integration/ExchangeRates/TransactionRatesHelperTest.php
+++ b/tests/Integration/ExchangeRates/TransactionRatesHelperTest.php
@@ -1,0 +1,33 @@
+<?php
+
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use App\Helper\NbpRatesHelper;
+use App\Helper\TransactionRatesHelper;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class TransactionRatesTest extends WebTestCase {
+    public function testRatesCalculation() {
+        $mockDate = '2024-11-01';
+        $mockNbp =  $this->getMockBuilder(NbpRatesHelper::class)->disableOriginalConstructor()->setMethods(['getRates'])->getMock();
+
+        $mockNbp->method('getRates')->willReturn(['date'=>$mockDate, 'rates'=>$this->createMockRates()]);
+        $transactionHelper = new TransactionRatesHelper($mockNbp);
+
+        $expectedRateUSD = ['code'=>'USD','buy'=>1.2-0.05, 'sell'=>1.2+0.07];
+        $expectedRateCZK = ['code'=>'CZK','buy'=>null, 'sell'=>1.2+0.15];
+        $this->assertEquals(['date'=>$mockDate, 'rates'=>[$expectedRateUSD, $expectedRateCZK]],$transactionHelper->getRates($mockDate));
+    }
+
+    private function createMockRates() {
+        $rates = [];
+        foreach(['USD','CZK'] as $code) {
+            $rate = new stdClass();
+            $rate->code = $code;
+            $rate->mid = 1.20;
+            $rates[] = $rate;
+        }
+        return $rates;
+    }
+}


### PR DESCRIPTION
1. Poświęcony czas: ok 6-8h
2. Feedback do zadania: ze względu na "zakaz" instalowania dodatkowych pakietów, nie można zrobić testów dla UI ani przejść na typescript.
3. Uwagi
3.1 Chciałem przekonwertować UI na typescript, ale "zakaz" instalowania nowych pakietów to uniemożliwia, mimo wszystko swój kod dołożyłem jako komponent funkcjonalny
3.2 Jeżeli użytkownik ogląda kursy dzisiejsze nie ma sensu pokazywać kolumny porównawczej z kursami z dzisiaj. Jest widoczna dla innych dat.
3.3 Dodałem cache dla requestów do NBP
3.4 W przypadku zapytania o kurs z dnia w którym nie ma dostępnego kursu, rekurencyjnie cofam się o 1 dzień, żeby zaoszczędzić na niepotrzebnych requestach, jeśli mamy 404 z NBP w poniedziałek cofam się o 3 dni (do piątku), jeżeli niedzielę to o 2 dni (też do piątku), tak żeby pozyskać kurs w 2 requestach. W przypadku świąt państwowych itp będą potrzebne dodatkowe requesty (sygnalizuję, że można optymalizować to dalej, ale na zadanie rekrutacyjne wystarczy tak jak jest)
3.4.2 Zeby uniknąć nieskończonych pętli z requestami, dodałem ograniczenie rekurencji do max 5 requestów.
3.5 Ze względu na ograniczony czas pokrycie testami dość "symboliczne"